### PR TITLE
Ensuring the config files are getting applied in order

### DIFF
--- a/cotton/config.py
+++ b/cotton/config.py
@@ -57,21 +57,20 @@ def get_config():
     # If a preferred location is specified in the hash the old path is deprecated and a warning
     # should be shown
     config_files = [
-        {'path': '~/.cotton.yaml'},
-        {'path': '~/.config.yaml',             'preferred': '~/.cotton.yaml'},
-        {'path': '../config.user/config.yaml', 'preferred': '~/.cotton.yaml'},
+        {'path': '../config/config.yaml',      'preferred': '../config/cotton.yaml'},
         {'path': '../config/cotton.yaml'},
-        {'path': '../config/config.yaml',      'preferred': '../config/cotton.yaml'}
+        {'path': '../config.user/config.yaml', 'preferred': '~/.cotton.yaml'},
+        {'path': '~/.config.yaml',             'preferred': '~/.cotton.yaml'},
+        {'path': '~/.cotton.yaml'}
     ]
     if 'project' in env and env.project:
-        config_files.insert(1, {'path': '../config/projects/{}/config.yaml'.format(env.project),
-                                'preferred': '../config/projects/{}/project.yaml'.format(env.project)})
-        config_files.insert(1, {'path': '../config/projects/{}/project.yaml'.format(env.project)})
+        config_files.append({'path': '../config/projects/{}/project.yaml'.format(env.project)})
+        config_files.append({'path': '../config/projects/{}/config.yaml'.format(env.project),
+                             'preferred': '../config/projects/{}/project.yaml'.format(env.project)})
 
     config = {}
     for config_file in config_files:
         config_filename = os.path.expanduser(config_file.get('path'))
-        data = {}
         try:
             data = _load_config_file(config_filename)
             print(green("Loaded config: {}".format(config_filename)))


### PR DESCRIPTION
Previously the .pop() option meant that the config_files were
being applied from the end of the list to the front. This
change has reordered the list the other way around.
