### PR TITLE
fix __exit_ in GitSshEnvWrapper

### DIFF
--- a/cotton/salt_shaker.py
+++ b/cotton/salt_shaker.py
@@ -215,6 +215,7 @@ class Shaker(object):
                 sys.stdout.write("Resetting sha mismatch on: {}\n".format(formula['name']))
                 logging.debug(formula)
                 repo.head.reset(commit=sha, index=True, working_tree=True)
+
             self.logger.debug("{formula[name]} {formula[revision]}".format(formula=formula))
 
         source = os.path.join(repo_dir, formula['name'])


### PR DESCRIPTION
Fix for:
...cotton/cotton/salt_shaker.py", line 219, in install_requirement
    self.logger.debug("{formula[name]} {formula[revision]}".format(formula=formula))
TypeError: **exit**() takes exactly 1 argument (4 given)
