### PR TITLE
Added support for non default subnets/vpcs

### DIFF
--- a/cotton/provider/aws/driver.py
+++ b/cotton/provider/aws/driver.py
@@ -52,8 +52,19 @@ class AWSProvider(Provider):
         run_instances_args['image_id'] = zone_config['image_id']
         run_instances_args['key_name'] = zone_config['provisioning_ssh_key_name']
         run_instances_args['instance_type'] = zone_config['instance_type']
-        if 'security_groups' in zone_config:
-            run_instances_args['security_groups'] = zone_config['security_groups']
+
+        if 'subnet_id' in zone_config:
+            print("Found subnet_id - creating instance within VPC")
+            run_instances_args['subnet_id'] = zone_config['subnet_id']
+            if 'security_groups' in zone_config:
+                raise ValueError("VPC does not accept security_groups - use security_groups_ids instead")
+            if 'security_groups_ids' in zone_config:
+                run_instances_args['security_group_ids'] = zone_config['security_groups_ids']
+        else:
+            if 'security_groups_ids' in zone_config:
+                raise ValueError("Non VPC does not accept security_group_ids - use security_groups instead")
+            if 'security_groups' in zone_config:
+                run_instances_args['security_groups'] = zone_config['security_groups']
 
         reservation = self.connection.run_instances(**run_instances_args)
         instance = reservation.instances[0]


### PR DESCRIPTION
If you specify the subnet_id in the provider zone you can now target a non default VPC.

NB: Using this style of VPC you need to use security_group_ids and specify the list of ids and not the names of the security groups. This is a limitation of the API.
