### PR TITLE
Add ability to load Vagrant project.yaml

### DIFF
--- a/cotton/config.py
+++ b/cotton/config.py
@@ -76,7 +76,7 @@ def get_config():
         config_files.append({'path': '../config/projects/{}/project.yaml'.format(env.project)})
 
     if 'provider_zone' in env and 'vagrant' in env.provider_zone:
-        config_files.append({'path': 'vagrant/project.yaml'})
+        config_files.append({'path': 'vagrant/cotton.yaml'})
 
     os_env_cotton_config = os.environ.get('COTTON_CONFIG', None)
     if os_env_cotton_config:


### PR DESCRIPTION
For Vagrant-based deploys, we want to remove the need to have the
config repo present.

If env.provider_zone contains 'vagrant', load a local project.yaml
file from ./vagrant/project.yaml
