### PR TITLE
Gateway user override for provisioning

### DIFF
--- a/cotton/api.py
+++ b/cotton/api.py
@@ -135,7 +135,10 @@ def configure_fabric_for_host(name):
             env.key_filename = zone_config['ssh_key']
 
     if 'gateway' in zone_config:
-        env.gateway = '{}@{}'.format(env.user, zone_config['gateway'])
+        if 'gateway_user' in env and env.gateway_user:
+            env.gateway = '{}@{}'.format(env.gateway_user, zone_config['gateway'])
+        else:
+            env.gateway = '{}@{}'.format(env.user, zone_config['gateway'])
 
 
 def dict_stringize_keys(data):

--- a/cotton/ssh_utils.py
+++ b/cotton/ssh_utils.py
@@ -9,6 +9,10 @@ from fabric.api import task
 
 
 def ssh_gateway(user, host):
+
+    if "gateway_user" in env and env.gateway_user:
+        user = env.gateway_user
+
     if host.find('@') != -1:
         remote_prefix = host
     elif host.count(':') > 1:
@@ -164,7 +168,6 @@ def rsync_project(
         print("[%s] rsync_project: %s" % (env.host_string, cmd))
     return local(cmd, capture=capture)
 
-
 @task
 @needs_host
 def ssh(ssh_opts='', remote_cmd=None):
@@ -196,6 +199,8 @@ def ssh(ssh_opts='', remote_cmd=None):
         gw_port_string = "-p %s" % gw_port
         if '@' in env.gateway:
             gw_user_host_string = env.gateway
+        elif "gateway_user" in env and env.gateway_user:
+            gw_user_host_string = ssh_host_string(env.gateway_user, env.gateway)
         else:
             gw_user_host_string = ssh_host_string(user, env.gateway)
         proxy_string = '-o "ProxyCommand ssh {key_string} {ssh_opts} {gw_port_string} {gw_user_host_string} nc %h %p"'.format(


### PR DESCRIPTION
The 'provisioning' mode was not particularly useful when reprovisioning
nodes in an environment -- it assumes that the entire env is fresh, and
that the 'provisioning' user is available on the gateway.

For security reasons, this should never be the case on an existing gateway.

Hence, allow for a 'gateway_user' var to be specified, generally in your ~/.fabricrc
which will be used for connection to the gateway, regardless of whether env.user has
been overwritten by 'provisioning'.

This means we can delete and recreate, and reprovision, a node in a cluster with our
common fab tasks, such as:
- Delete node (plus ssh and salt key references)
- Recreate node from fresh template (eg via vcloud-launch)
- Bootstrap salt with `fab provisioning zone:{env} workon:{node} bootstrap_minion`
- Run highstate as normal
