### PR TITLE
Aws private ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.5.1
+
+ * Allow to ssh through jumpbox to VMs w/o public dns entry (EC2)
+
 ## Version 0.5.0
 
  * Allow to disable top.sls parsing when shipping pillars

--- a/cotton/provider/aws/driver.py
+++ b/cotton/provider/aws/driver.py
@@ -235,5 +235,9 @@ class AWSProvider(Provider):
         return info_dict
 
     def host_string(self, server):
-        #TODO: where to select user/provisioning mode
-        return self.info(server)["hostname"]
+        if self.info(server)["hostname"]:
+            # public dns entry is available
+            return self.info(server)["hostname"]
+        else:
+            # only private ip is available so user will need to be using jumpbox
+            return self.info(server)["ip"]


### PR DESCRIPTION
for vms with private only ip return ip address instead of public_dns_entry for fabric to be able to ssh (i.e. through jump box)
